### PR TITLE
add: black text default

### DIFF
--- a/lib/InteractiveTextInput.style.ts
+++ b/lib/InteractiveTextInput.style.ts
@@ -1,4 +1,10 @@
-import { ViewStyle, Dimensions, ImageStyle, StyleSheet } from "react-native";
+import {
+  ViewStyle,
+  Dimensions,
+  ImageStyle,
+  StyleSheet,
+  TextStyle,
+} from "react-native";
 const { width: ScreenWidth } = Dimensions.get("screen");
 
 interface Style {
@@ -7,7 +13,7 @@ interface Style {
   iconImageStyle: ImageStyle;
 }
 
-export const _textInputStyle = (borderColor: any): ViewStyle => ({
+export const _textInputStyle = (borderColor: any): TextStyle => ({
   height: 50,
   width: ScreenWidth * 0.9,
   borderWidth: 1,
@@ -17,6 +23,7 @@ export const _textInputStyle = (borderColor: any): ViewStyle => ({
   borderColor: borderColor,
   justifyContent: "center",
   backgroundColor: "#eceef5",
+  color: "#000",
 });
 
 export default StyleSheet.create<Style>({


### PR DESCRIPTION
Text will show up as white on some android themes if you don't specifically set it to black. Here's an example from using your LoginScreen library.

<img width="415" alt="Screen Shot 2022-08-17 at 4 26 49 PM" src="https://user-images.githubusercontent.com/14174629/185160033-b0e50cca-838d-4b2a-8ab7-2776589b6161.png">
 